### PR TITLE
[YEET-84] Update notify-slack-pipeline action to use passed message

### DIFF
--- a/.github/workflows/actions/notify-slack-pipeline-status/action.yaml
+++ b/.github/workflows/actions/notify-slack-pipeline-status/action.yaml
@@ -33,5 +33,5 @@ runs:
     - name: run the action
       uses: ./action
       with:
-        message: monolith has been deployed to production.
+        message: {{ inputs.message }}
         slack_webhook_url: ${{ inputs.slack_webhook_url }}


### PR DESCRIPTION
Instead of a hardcoded 'monolith has been deployed to production', this uses the passed message which can generate a different branch.