### PR TITLE
Use Node 16 actions to remove deprecation warnings about Node 12

### DIFF
--- a/.github/workflows/actions/deploy-to-tenant/action.yaml
+++ b/.github/workflows/actions/deploy-to-tenant/action.yaml
@@ -94,13 +94,13 @@ runs:
         fetch-depth: 1
 
     - name: "Install Doppler CLI"
-      uses: dopplerhq/cli-action@v1
+      uses: dopplerhq/cli-action@v2
 
     - name: 'Install Kubectl'
       id: install-kubectl
-      uses: azure/setup-kubectl@v1
+      uses: azure/setup-kubectl@v3
       with:
-        version: v1.19.0
+        version: v1.21.0
 
     - name: 'Install and Setup Helm'
       uses: Azure/setup-helm@v3.3
@@ -135,7 +135,7 @@ runs:
         base-chart-version: ${{ inputs.chart-version }}
 
     - name: "Configure AWS credentials"
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}

--- a/.github/workflows/actions/ecr-login/action.yaml
+++ b/.github/workflows/actions/ecr-login/action.yaml
@@ -30,7 +30,7 @@ runs:
         echo "::add-mask::${{ inputs.aws-secret-access-key }}"
 
     - name: 'Configure AWS Credentials - USE'
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       if: ${{ contains(fromJSON(inputs.regions), 'us-east-1') }}
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
@@ -49,7 +49,7 @@ runs:
         echo "::set-output name=repo::${{ steps.login-ecr-use.outputs.registry }}/cache/${{ inputs.image-name }}"
 
     - name: 'Configure AWS Credentials - EUC'
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       if: ${{ contains(fromJSON(inputs.regions), 'eu-central-1') }}
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
@@ -62,7 +62,7 @@ runs:
       uses: aws-actions/amazon-ecr-login@v1
 
     - name: 'Configure AWS credentials - EUW-1'
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       if: ${{ contains(fromJSON(inputs.regions), 'eu-west-1') }}
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
@@ -75,7 +75,7 @@ runs:
       uses: aws-actions/amazon-ecr-login@v1
 
     - name: 'Configure AWS credentials - EUW-3'
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       if: ${{ contains(fromJSON(inputs.regions), 'eu-west-3') }}
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
@@ -88,7 +88,7 @@ runs:
       uses: aws-actions/amazon-ecr-login@v1
 
     - name: 'Configure AWS credentials - APS'
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       if: ${{ contains(fromJSON(inputs.regions), 'ap-south-1') }}
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}


### PR DESCRIPTION
While watching this deploy, I saw we were getting some deprecation warnings: https://github.com/onboardiq/pool/actions/runs/3267006160

Node.js 12 actions are deprecated: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

I've updated the dopplerhq/cli, Azure/setup-kubectl, and aws-actions/configure-aws-credentials to reflect this. I've also updated kubectl to `1.21.0` since that's the version we're running in AWS.

The changelogs for each action and relevant info:
* [dopplerhq/cli](https://github.com/DopplerHQ/cli-action/releases)
* [Azure/setup-kubectl](https://github.com/Azure/setup-kubectl/releases)
  * We're jumping from v1 to v3 here but the changelog doesn't seem to indicate any breaking changes.
* [aws-actions/configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials#notice-node12-deprecation-warning)
  * https://github.com/aws-actions/configure-aws-credentials/issues/489#issuecomment-1278145876 