### PR TITLE
[YEET] Turn off fail fast for cd-common

### DIFF
--- a/.github/workflows/cd-common.yaml
+++ b/.github/workflows/cd-common.yaml
@@ -110,6 +110,7 @@ jobs:
       - deploy-env
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include: ${{ fromJSON(inputs.tenants) }}
     steps:


### PR DESCRIPTION
This will prevent GH Actions from cancelling parallel deploy jobs and requiring
confusing, long rollback lists.