### PR TITLE
Checks out the branch that is deployed

### DIFF
--- a/.github/workflows/actions/merge-stable-to-master/action.yaml
+++ b/.github/workflows/actions/merge-stable-to-master/action.yaml
@@ -23,6 +23,7 @@ runs:
       uses: actions/checkout@v3
       with:
         token: ${{ inputs.github-automation-token }}
+        ref: ${{ inputs.sha }}
 
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
I have setup `ms-nlu` repository to deploy automatically on successful builds on stable branch. 

Currently the builds are seeming to fail at this step. Refer https://github.com/onboardiq/ms-nlu/actions/runs/4852685252/jobs/8654833163

I wonder if this is the fix needed to make sure the code is able to checkout the SHA that is actually being deployed