### PR TITLE
Remove merge-stable-to-master

### DIFF
--- a/.github/workflows/cd-common.yaml
+++ b/.github/workflows/cd-common.yaml
@@ -159,13 +159,6 @@ jobs:
           repository: onboardiq/gh-common-workflows
           path: ./common-workflows
           fetch-depth: 1
-
-      - uses: ./common-workflows/.github/workflows/actions/merge-stable-to-master
-        with:
-          sha: ${{ needs.deploy-env.outputs.commit-sha }}
-          github-automation-token: ${{ secrets.github-automation-token }}
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-
       - uses: ./common-workflows/.github/workflows/actions/create-github-deployment
         with:
           github-automation-token: ${{ secrets.github-automation-token }}


### PR DESCRIPTION
This has continuously confused our new RM's assuming that deploy jobs have failed when really this step is just the problem.  We should remove until we have a fix for it