### PR TITLE
Allow `stable` to run a rake task on uat

### DIFF
--- a/.github/workflows/run-task.yaml
+++ b/.github/workflows/run-task.yaml
@@ -101,16 +101,14 @@ jobs:
           script: |
             const { DEPLOY_ENVIRONMENT, BRANCH } = process.env;
 
-            const matches_prod = DEPLOY_ENVIRONMENT === 'prod' && BRANCH === 'stable';
-            const matches_uat = DEPLOY_ENVIRONMENT === 'uat'
-              && (
-                BRANCH.startsWith('release/')
-                || BRANCH.startsWith('hotfix/')
-              );
+            // only allow prod to deploy from stable, also allow release/* and hotfix/* (with stable) for uat, and any branch for dev
+            const allowed_branches_regex = {
+              prod: '^stable$',
+              uat: '^(stable|release/.*|hotfix/.*)$',
+              dev: '.*',
+            };
 
-            const matches_dev = DEPLOY_ENVIRONMENT === 'dev';
-
-            const valid = matches_prod || matches_uat || matches_dev;
+            const valid = new RegExp(allowed_branches_regex[DEPLOY_ENVIRONMENT]).test(BRANCH);
 
             if (!valid) {
               core.setFailed(`Supplied argument for branch didn't match deploy environment. Supplied: ${DEPLOY_ENVIRONMENT} and ${BRANCH}, which are incompatible.`);


### PR DESCRIPTION
Context: https://fountain.slack.com/archives/C03CZB0PWK1/p1684247748213659

## Tests
Monolith branch to use this workflow: https://github.com/onboardiq/monolith/commit/10c3ce0ce3646ba2b91551bbf93d9271e3411ef1

- `stable` on `uat` - ✅ (as expected) - https://github.com/onboardiq/monolith/actions/runs/5045741732
- `chore/test-run-rake-task-with-stable-on-uat` on `uat` - ❌ (as expected, my test non-hotfix/release/stable branch) - https://github.com/onboardiq/monolith/actions/runs/5045831184
- `hotfix/test` on `uat` - ✅ (as expected) - https://github.com/onboardiq/monolith/actions/runs/5045878109
- `hotfix/test` on `prod` - ❌ (as expected) - https://github.com/onboardiq/monolith/actions/runs/5045805978 (used the latest hotfix/ existing branch, I tried initially with `hotfix/test` EXPLICITLY, but that doesn't exist and it still tried to clone it before checking it in https://github.com/onboardiq/monolith/actions/runs/5045773476 🤔)
- `chore/test-run-rake-task-with-stable-on-uat` on `prod` - ❌ (as expected) - https://github.com/onboardiq/monolith/actions/runs/5045849774
- `stable` on `prod` - ✅ (as expected) - https://github.com/onboardiq/monolith/actions/runs/5045901573
- `chore/test-run-rake-task-with-stable-on-uat` on `dev` - ✅ (as expected) - https://github.com/onboardiq/monolith/actions/runs/5045888277