### PR TITLE
[Feature] New input 'helm-makefile-location' for CD deploys

### DIFF
--- a/.github/workflows/actions/deploy-to-tenant/action.yaml
+++ b/.github/workflows/actions/deploy-to-tenant/action.yaml
@@ -68,6 +68,10 @@ inputs:
     description: "The deployment environment PROD | UAT | DEV"
     required: true
     type: string
+  helm-makefile-location:
+    description: "Path to directory from the repo root where the helm Makefile is present"
+    required: true
+    type: string
 
 runs:
   using: 'composite'
@@ -173,7 +177,7 @@ runs:
       shell: bash
       run: |
         kubectl config use-context aws-${{ inputs.region }}-${{ inputs.context }}
-        make -C helm test
+        make -C ${{ inputs.helm-makefile-location }} test
 
     - name: 'Deployment - LIVE'
       if: ${{ inputs.dry-run == 'false' || inputs.dry-run == false }}
@@ -195,4 +199,4 @@ runs:
       shell: bash
       run: |
         kubectl config use-context aws-${{ inputs.region }}-${{ inputs.context }}
-        make -C helm install
+        make -C ${{ inputs.helm-makefile-location }} install

--- a/.github/workflows/cd-common.yaml
+++ b/.github/workflows/cd-common.yaml
@@ -56,7 +56,11 @@ on:
         description: "The message to post on successful deployment"
         type: string
         required: true
-
+      helm-makefile-location:
+        description: "Path to directory from the repo root where the helm Makefile is present"
+        type: string
+        required: false
+        default: 'helm'
     secrets:
       aws-access-key-id:
         description: "An AWS Access Key ID with sufficient access to push to ECR repos"
@@ -146,6 +150,7 @@ jobs:
           helm_repo_username: ${{ secrets.helm-repo-username }}
           helm_repo_password: ${{ secrets.helm-repo-password }}
           project-name: ${{ inputs.project-name }}
+          helm-makefile-location: ${{ inputs.helm-makefile-location }}
 
   release:
     needs:


### PR DESCRIPTION
Need a new input to suggest the location of helm Makefile in case `helm` directory is not present in the repo root. This will most likely be the case for monorepos.