### PR TITLE
[Feature] Support when doppler project is different from repo name

### DIFF
--- a/.github/workflows/actions/deploy-to-tenant/action.yaml
+++ b/.github/workflows/actions/deploy-to-tenant/action.yaml
@@ -72,6 +72,10 @@ inputs:
     description: "Path to directory from the repo root where the helm Makefile is present"
     required: true
     type: string
+  doppler-project-name:
+    description: "Name of the doppler project. Its often same as 'project-name'"
+    required: true
+    type: string
 
 runs:
   using: 'composite'
@@ -151,7 +155,7 @@ runs:
       if: ${{ (inputs.doppler-token != 0 && inputs.doppler-token != '') && (inputs.dry-run == 'false' || inputs.dry-run == false) }}
       uses: ./common-workflows/.github/workflows/actions/manage-doppler-secret
       with:
-        doppler-project: ${{ inputs.project-name }}
+        doppler-project: ${{ inputs.doppler-project-name }}
         tenant-name: ${{ inputs.tenant-name }}
         namespace: ${{ inputs.namespace }}
         environment: ${{ inputs.env }}

--- a/.github/workflows/cd-common.yaml
+++ b/.github/workflows/cd-common.yaml
@@ -61,6 +61,11 @@ on:
         type: string
         required: false
         default: 'helm'
+      doppler-project-name:
+        description: "Name of the doppler project. Its often same as 'project-name'"
+        type: string
+        required: false
+        default:
     secrets:
       aws-access-key-id:
         description: "An AWS Access Key ID with sufficient access to push to ECR repos"
@@ -151,6 +156,7 @@ jobs:
           helm_repo_password: ${{ secrets.helm-repo-password }}
           project-name: ${{ inputs.project-name }}
           helm-makefile-location: ${{ inputs.helm-makefile-location }}
+          doppler-project-name: ${{ inputs.doppler-project-name || inputs.project-name }}
 
   release:
     needs:


### PR DESCRIPTION
In case of monorepos, multiple projects within same repo will have different dopplre project names