### PR TITLE
Add optional sha input to cd-common so deploys pin the built commit

### DIFF
--- a/.github/workflows/cd-common.yaml
+++ b/.github/workflows/cd-common.yaml
@@ -23,6 +23,11 @@ on:
         description: "The branch or tag name or SHA to check out"
         required: true
         type: string
+      sha:
+        description: "Exact commit SHA to deploy (e.g. the commit the prepare workflow built). When set, it is checked out instead of resolving ref, so image tags and chart versions match the built artifacts even if the branch has moved on. ref is still used for tag/version naming."
+        required: false
+        type: string
+        default: ''
       dry-run:
         description: "When true, only does a dry run of deployment"
         required: true
@@ -115,7 +120,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.sha || inputs.ref }}
           fetch-depth: 1
       - name: 'Get the commit sha'
         id: commit-sha


### PR DESCRIPTION
## What

Adds an optional `sha` input to the `cd-common.yaml` reusable workflow. When provided, the `deploy-env` job checks out that exact commit instead of resolving the `ref` branch name at deploy time. `ref` is still used for image-tag / chart-version naming (`<branch>-<sha7>`), so artifact names continue to match what the prepare workflow published. Callers that don't pass `sha` see no behavior change.

## Why

`deploy-env` currently derives the commit to deploy via `git rev-parse HEAD` after checking out the branch. Prepare workflows build artifacts for a specific commit and dispatch the deploy with that SHA (e.g. megalith's `fountain-ai-prepare-images-and-charts.yaml` passes `-f sha=...`), but cd-common has no way to receive it — so any commit landing on the branch between build and deploy makes cd-common compute a chart/image version that was never built.

This exact race broke today's fountain-ai stage deploy: chart `1.0.0-075b75e-main` was built at 12:28, an unrelated WX commit `1088dd3` landed on `main` at 12:33, and the 12:36 deploy resolved head-of-main and failed with `fountain-ai-chart:1.0.0-1088dd3-main: not found` (https://github.com/onboardiq/megalith/actions/runs/28943055278/job/85869968854).

Note: passing the SHA as `ref` (the pattern some `*-deploy.yaml` callers use) is not a fix — the `version` action computes `image-tag=${REF##*/}-${SHA::7}`, so a bare SHA as `ref` produces a tag that doesn't match the built `branch-<sha7>` artifacts. Checkout needs the SHA; naming needs the branch — hence the separate input.

## Follow-up

Callers should pass `sha` through from their dispatch inputs and bump their pin to the merged commit. A megalith PR wiring this up for fountain-ai will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)